### PR TITLE
Revert "change regex for kiwi-ng"

### DIFF
--- a/lib/sle2docker/rootfs_image.rb
+++ b/lib/sle2docker/rootfs_image.rb
@@ -63,12 +63,8 @@ module Sle2Docker
     private
 
     def compute_repository_and_tag
-      # example of image name:
-      # kiwi < 8.0 :
-      #      sles12-docker.x86_64-1.0.0-Build7.2
-      # kiwi >= 8.0
-      #      obs-source-service.x86_64-1.0.0-Build3.1.docker
-      regexp = /\A(?<name>.*)(-docker)?\..*-(?<version>\d+\.\d+\.\d+)
+      # example of image name: sles12-docker.x86_64-1.0.0-Build7.2
+      regexp = /\A(?<name>.*)-docker\..*-(?<version>\d+\.\d+\.\d+)
        (-Build(?<build>\d+\.\d+)?)?/x
       match = regexp.match(@image_name)
       match.nil? &&

--- a/test/rootfs_image_test.rb
+++ b/test/rootfs_image_test.rb
@@ -82,10 +82,10 @@ DOCKERFILE
         tmp_dir = '/foo'
         mocked_image = mock
         mocked_image.expects(:tag)
-                    .with('repo' => 'suse/sles12-docker', 'tag' => '1.0.0')
+                    .with('repo' => 'suse/sles12', 'tag' => '1.0.0')
                     .once
         mocked_image.expects(:tag)
-                    .with('repo' => 'suse/sles12-docker', 'tag' => 'latest')
+                    .with('repo' => 'suse/sles12', 'tag' => 'latest')
                     .once
 
         prebuilt_image = Sle2Docker::RootFSImage.new(
@@ -112,10 +112,10 @@ DOCKERFILE
         tmp_dir = '/foo'
         mocked_image = mock
         mocked_image.expects(:tag)
-                    .with('repo' => 'suse/sles12-docker', 'tag' => '1.0.0-7.2')
+                    .with('repo' => 'suse/sles12', 'tag' => '1.0.0-7.2')
                     .once
         mocked_image.expects(:tag)
-                    .with('repo' => 'suse/sles12-docker', 'tag' => 'latest')
+                    .with('repo' => 'suse/sles12', 'tag' => 'latest')
                     .once
 
         prebuilt_image = Sle2Docker::RootFSImage.new(
@@ -136,10 +136,10 @@ DOCKERFILE
         tmp_dir = '/foo'
         mocked_image = mock
         mocked_image.expects(:tag)
-                    .with('repo' => 'suse/sles12-docker', 'tag' => '1.0.0-0.0')
+                    .with('repo' => 'suse/sles12', 'tag' => '1.0.0-0.0')
                     .once
         mocked_image.expects(:tag)
-                    .with('repo' => 'suse/sles12-docker', 'tag' => 'latest')
+                    .with('repo' => 'suse/sles12', 'tag' => 'latest')
                     .once
 
         prebuilt_image = Sle2Docker::RootFSImage.new(


### PR DESCRIPTION
This reverts commit 28fdfb1e6049f186f1555056748261a784fe9915.
This commit introduced a regression, as the regex was including
'-docker' as part of the name in builds done with kiwi < 8. Also
this is no longer needed since kiwi-ng builds are handled in
native_images class, now this regex applies only for old builds.

Fixes bsc#1064010